### PR TITLE
feat: main menu scene with in-progress game restore on relaunch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,31 @@ jobs:
 
       - name: Select iOS simulator destination
         run: |
-          ios_device_name="$(xcrun simctl list devices available | sed -n 's/^[[:space:]]*\\(iPhone[^)]*\\) (.*/\\1/p' | head -n 1)"
-          if [ -z "$ios_device_name" ]; then
+          ios_destination="$(
+            xcrun simctl list devices available -j | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+devices = payload.get("devices", {})
+
+for runtime, runtime_devices in sorted(devices.items(), reverse=True):
+    if "iOS" not in runtime:
+        continue
+    for device in runtime_devices:
+        if device.get("isAvailable") and device.get("name", "").startswith("iPhone"):
+            print(f"platform=iOS Simulator,id={device[\"udid\"]}")
+            raise SystemExit(0)
+
+raise SystemExit(1)
+'
+          )"
+          if [ -z "$ios_destination" ]; then
             echo "No available iPhone simulator found" >&2
             exit 1
           fi
-          echo "Using iOS simulator: $ios_device_name"
-          echo "IOS_DESTINATION=platform=iOS Simulator,name=$ios_device_name" >> "$GITHUB_ENV"
+          echo "Using iOS simulator destination: $ios_destination"
+          echo "IOS_DESTINATION=$ios_destination" >> "$GITHUB_ENV"
 
       - name: Build for iOS Simulator
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   PROJECT_FILE: tictactoe.xcodeproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,9 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
         xcode-version: ['16.0', 'latest-stable']
-        include:
-          - xcode-version: '16.0'
-            ios-version: '17.5'
-            macos-version: '14.5'
-          - xcode-version: 'latest-stable'
-            ios-version: 'latest'
-            macos-version: 'latest'
 
     steps:
       - name: Checkout repository
@@ -66,12 +60,22 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Select iOS simulator destination
+        run: |
+          ios_device_name="$(xcrun simctl list devices available | sed -n 's/^[[:space:]]*\\(iPhone[^)]*\\) (.*/\\1/p' | head -n 1)"
+          if [ -z "$ios_device_name" ]; then
+            echo "No available iPhone simulator found" >&2
+            exit 1
+          fi
+          echo "Using iOS simulator: $ios_device_name"
+          echo "IOS_DESTINATION=platform=iOS Simulator,name=$ios_device_name" >> "$GITHUB_ENV"
+
       - name: Build for iOS Simulator
         run: |
           xcodebuild clean build \
             -project "$PROJECT_FILE" \
             -scheme "$IOS_SCHEME" \
-            -destination "platform=iOS Simulator,name=iPhone 15,OS=${{ matrix.ios-version }}" \
+            -destination "$IOS_DESTINATION" \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO | xcpretty && exit ${PIPESTATUS[0]}
 
@@ -80,7 +84,7 @@ jobs:
           xcodebuild test \
             -project "$PROJECT_FILE" \
             -scheme "$IOS_SCHEME" \
-            -destination "platform=iOS Simulator,name=iPhone 15,OS=${{ matrix.ios-version }}" \
+            -destination "$IOS_DESTINATION" \
             -testPlan "$TEST_PLAN" \
             -enableCodeCoverage YES \
             CODE_SIGN_IDENTITY="" \
@@ -91,14 +95,14 @@ jobs:
           xcodebuild clean build \
             -project "$PROJECT_FILE" \
             -scheme "$MACOS_SCHEME" \
-            -destination "platform=macOS,arch=x86_64" | xcpretty && exit ${PIPESTATUS[0]}
+            -destination "platform=macOS" | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Test macOS
         run: |
           xcodebuild test \
             -project "$PROJECT_FILE" \
             -scheme "$MACOS_SCHEME" \
-            -destination "platform=macOS,arch=x86_64" \
+            -destination "platform=macOS" \
             -testPlan "$TEST_PLAN" \
             -enableCodeCoverage YES | xcpretty && exit ${PIPESTATUS[0]}
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,6 @@
 excluded:
   - Package.swift
+  - scripts/benchmark.swift
   - .build
   - Carthage
   - Pods

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,5 @@
 excluded:
+  - Package.swift
   - .build
   - Carthage
   - Pods
@@ -108,8 +109,6 @@ cyclomatic_complexity:
 nesting:
   type_level:
     warning: 3
-  statement_level:
-    warning: 5
 
 identifier_name:
   min_length:
@@ -144,7 +143,7 @@ file_header:
   required_pattern: |
                     \/\/
                     \/\/  .*?\.swift
-                    \/\/  tictactoe
+                    \/\/  tictactoe(?: (?:Shared|iOS|macOS))?
                     \/\/
                     \/\/  Created by .* on \d{1,2}\/\d{1,2}\/\d{2}\.
                     \/\/

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,9 @@ let package = Package(
             path: "tictactoe Shared",
             exclude: [
                 "Assets.xcassets",
-                "GameScene.swift"
+                "GameScene.swift",
+                "MainMenuScene.swift",
+                "GamePersistence.swift"
             ],
             sources: ["GameLogic.swift"]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -23,10 +23,12 @@ let package = Package(
             exclude: [
                 "Assets.xcassets",
                 "GameScene.swift",
-                "MainMenuScene.swift",
-                "GamePersistence.swift"
+                "MainMenuScene.swift"
             ],
-            sources: ["GameLogic.swift"]
+            sources: [
+                "GameLogic.swift",
+                "GamePersistence.swift"
+            ]
         ),
         .testTarget(
             name: "TicTacToeCoreTests",

--- a/TicTacToeTests/TicTacToeTests.swift
+++ b/TicTacToeTests/TicTacToeTests.swift
@@ -459,4 +459,167 @@ final class GameLogicTests {
         #expect(logic?.boardSize == 7)
         #expect(logic?.gameState == .ongoing)
     }
+
+    // MARK: - Snapshot / Restore Tests
+
+    @Test("Snapshot round-trip preserves board, current player, and state for ongoing game")
+    func testSnapshotRoundTripOngoing() throws {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+        // X: (0,0), O: (1,1), X: (0,1)
+        _ = logic.makeMove(row: 0, col: 0)
+        _ = logic.makeMove(row: 1, col: 1)
+        _ = logic.makeMove(row: 0, col: 1)
+
+        let snap = logic.snapshot()
+        guard let restored = GameLogic(snapshot: snap) else {
+            #expect(Bool(false), "GameLogic should restore from a valid snapshot")
+            return
+        }
+
+        #expect(restored.boardSize == logic.boardSize, "boardSize should match after round-trip")
+        #expect(restored.gameState == .ongoing, "gameState should be ongoing after round-trip")
+        #expect(restored.currentPlayer == logic.currentPlayer, "currentPlayer should match after round-trip")
+
+        for r in 0..<logic.boardSize {
+            for c in 0..<logic.boardSize {
+                #expect(
+                    restored.getPlayerAt(row: r, col: c) == logic.getPlayerAt(row: r, col: c),
+                    "Cell (\(r),\(c)) should match after round-trip"
+                )
+            }
+        }
+    }
+
+    @Test("Snapshot round-trip preserves won state and winning coordinates")
+    func testSnapshotRoundTripWon() throws {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+        // Drive X to win the top row: X(0,0) O(1,0) X(0,1) O(1,1) X(0,2)
+        _ = logic.makeMove(row: 0, col: 0)
+        _ = logic.makeMove(row: 1, col: 0)
+        _ = logic.makeMove(row: 0, col: 1)
+        _ = logic.makeMove(row: 1, col: 1)
+        _ = logic.makeMove(row: 0, col: 2)
+
+        #expect(logic.gameState == .won(.x), "Setup should result in X winning")
+
+        let snap = logic.snapshot()
+        guard let restored = GameLogic(snapshot: snap) else {
+            #expect(Bool(false), "GameLogic should restore from a won-state snapshot")
+            return
+        }
+
+        #expect(restored.gameState == .won(.x), "Restored game should show X winning")
+        let coords = restored.getWinningPatternCoordinates()
+        #expect(coords != nil, "Winning coordinates should be available after restore")
+        #expect(coords?.count == 3, "Should have 3 winning coordinates")
+        let expected: Set<String> = ["0,0", "0,1", "0,2"]
+        #expect(Set(coords!.map { "\($0.row),\($0.col)" }) == expected, "Winning row 0 should be restored")
+    }
+
+    @Test("Snapshot round-trip preserves draw state")
+    func testSnapshotRoundTripDraw() throws {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+        // Draw sequence on a 3x3 — produces:
+        // X O X
+        // X X O
+        // O X O
+        let drawMoves: [(Int, Int)] = [
+            (0, 0), (0, 1), (0, 2), (1, 2),
+            (1, 0), (2, 0), (1, 1), (2, 2),
+            (2, 1)
+        ]
+        makeMoves(logic, moves: drawMoves)
+        #expect(logic.gameState == .draw, "Setup should result in a draw")
+
+        let snap = logic.snapshot()
+        guard let restored = GameLogic(snapshot: snap) else {
+            #expect(Bool(false), "GameLogic should restore from a draw-state snapshot")
+            return
+        }
+
+        #expect(restored.gameState == .draw, "Restored game should show draw")
+        for r in 0..<logic.boardSize {
+            for c in 0..<logic.boardSize {
+                #expect(
+                    restored.getPlayerAt(row: r, col: c) == logic.getPlayerAt(row: r, col: c),
+                    "Cell (\(r),\(c)) should match after draw round-trip"
+                )
+            }
+        }
+    }
+
+    @Test("Snapshot round-trip works for 4x4 board")
+    func testSnapshotRoundTrip4x4() throws {
+        guard let logic = GameLogic(boardSize: 4) else {
+            #expect(Bool(false), "GameLogic should initialize successfully with size 4")
+            return
+        }
+        _ = logic.makeMove(row: 0, col: 0) // X
+        _ = logic.makeMove(row: 3, col: 3) // O
+        _ = logic.makeMove(row: 2, col: 1) // X
+
+        let snap = logic.snapshot()
+        guard let restored = GameLogic(snapshot: snap) else {
+            #expect(Bool(false), "GameLogic should restore from a 4x4 snapshot")
+            return
+        }
+
+        #expect(restored.boardSize == 4, "boardSize should be 4 after round-trip")
+        #expect(restored.gameState == .ongoing, "gameState should be ongoing")
+        #expect(restored.currentPlayer == logic.currentPlayer, "currentPlayer should match")
+        for r in 0..<4 {
+            for c in 0..<4 {
+                #expect(
+                    restored.getPlayerAt(row: r, col: c) == logic.getPlayerAt(row: r, col: c),
+                    "Cell (\(r),\(c)) should match on 4x4 after round-trip"
+                )
+            }
+        }
+    }
+
+    @Test("Snapshot restore returns nil for invalid board size")
+    func testSnapshotRestoreFailsForInvalidBoardSize() {
+        let snap = GameSnapshot(boardSize: 0, xBoard: 0, oBoard: 0, currentPlayer: .x, gameState: .ongoing)
+        let restored = GameLogic(snapshot: snap)
+        #expect(restored == nil, "Restore should fail for boardSize 0")
+    }
+
+    @Test("Snapshot restore returns nil for negative xBoard")
+    func testSnapshotRestoreFailsForNegativeXBoard() {
+        let snap = GameSnapshot(boardSize: 3, xBoard: -1, oBoard: 0, currentPlayer: .x, gameState: .ongoing)
+        let restored = GameLogic(snapshot: snap)
+        #expect(restored == nil, "Restore should fail when xBoard is negative")
+    }
+
+    @Test("Snapshot restore returns nil for negative oBoard")
+    func testSnapshotRestoreFailsForNegativeOBoard() {
+        let snap = GameSnapshot(boardSize: 3, xBoard: 0, oBoard: -1, currentPlayer: .x, gameState: .ongoing)
+        let restored = GameLogic(snapshot: snap)
+        #expect(restored == nil, "Restore should fail when oBoard is negative")
+    }
+
+    @Test("Snapshot restore returns nil for overlapping bitboards")
+    func testSnapshotRestoreFailsForOverlappingBitboards() {
+        // Both boards claim bit 0 (cell 0,0)
+        let snap = GameSnapshot(boardSize: 3, xBoard: 1, oBoard: 1, currentPlayer: .o, gameState: .ongoing)
+        let restored = GameLogic(snapshot: snap)
+        #expect(restored == nil, "Restore should fail when xBoard and oBoard overlap")
+    }
+
+    @Test("Snapshot restore returns nil for out-of-range bits")
+    func testSnapshotRestoreFailsForOutOfRangeBits() {
+        // Bit 9 is outside a 3x3 board mask (0b111111111 = 511)
+        let snap = GameSnapshot(boardSize: 3, xBoard: 1 << 9, oBoard: 0, currentPlayer: .x, gameState: .ongoing)
+        let restored = GameLogic(snapshot: snap)
+        #expect(restored == nil, "Restore should fail when bitboard contains out-of-range bits")
+    }
 }

--- a/TicTacToeTests/TicTacToeTests.swift
+++ b/TicTacToeTests/TicTacToeTests.swift
@@ -519,7 +519,9 @@ final class GameLogicTests {
         #expect(coords != nil, "Winning coordinates should be available after restore")
         #expect(coords?.count == 3, "Should have 3 winning coordinates")
         let expected: Set<String> = ["0,0", "0,1", "0,2"]
-        #expect(Set(coords!.map { "\($0.row),\($0.col)" }) == expected, "Winning row 0 should be restored")
+        if let coords {
+            #expect(Set(coords.map { "\($0.row),\($0.col)" }) == expected, "Winning row 0 should be restored")
+        }
     }
 
     @Test("Snapshot round-trip preserves draw state")

--- a/TicTacToeTests/TicTacToeTests.swift
+++ b/TicTacToeTests/TicTacToeTests.swift
@@ -5,6 +5,7 @@
 //  Created by Kevin T. Coughlin on 10/29/24.
 //
 
+import Foundation
 import Testing
 @testable import TicTacToeCore // Import the SPM module
 

--- a/TicTacToeTests/TicTacToeTests.swift
+++ b/TicTacToeTests/TicTacToeTests.swift
@@ -33,6 +33,11 @@ final class GameLogicTests {
         #expect(logic.gameState == .draw, message)
     }
 
+    private func resetPersistenceStores() {
+        GamePersistence.clear()
+        StatsStore.reset()
+    }
+
     // MARK: - Initialization Tests
 
     @Test("Initial Game State Test (3x3)")
@@ -361,6 +366,103 @@ final class GameLogicTests {
          #expect(logic.getWinningPatternCoordinates() == nil, "Expected no winning pattern after reset")
     }
 
+    // MARK: - Undo Tests
+
+    @Test("Undo returns nil for a new game")
+    func testUndoReturnsNilForNewGame() {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+
+        #expect(logic.canUndo == false, "New games should not allow undo")
+        #expect(logic.undo() == nil, "Undo should return nil when no moves have been made")
+        #expect(logic.gameState == .ongoing, "Undo should not change the game state")
+        #expect(logic.currentPlayer == .x, "Undo should not change the current player")
+    }
+
+    @Test("Undo removes the last move and restores turn order")
+    func testUndoRemovesLastMoveAndRestoresCurrentPlayer() {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+
+        _ = logic.makeMove(row: 0, col: 0) // X
+        _ = logic.makeMove(row: 1, col: 1) // O
+
+        let undoneMove = logic.undo()
+
+        #expect(undoneMove == MoveRecord(row: 1, col: 1, player: .o), "Undo should return the last move")
+        #expect(logic.getPlayerAt(row: 1, col: 1) == nil, "Undo should clear the reverted cell")
+        #expect(logic.getPlayerAt(row: 0, col: 0) == .x, "Earlier moves should remain on the board")
+        #expect(logic.currentPlayer == .o, "Undo should restore the player whose move was undone")
+        #expect(logic.gameState == .ongoing, "Undo should leave the game in progress")
+        #expect(logic.canUndo == true, "Undo should still be available while history remains")
+    }
+
+    @Test("Undo reverts a winning move back to an ongoing game")
+    func testUndoRevertsWinState() {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+
+        makeMoves(logic, moves: [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2)])
+        #expect(logic.gameState == .won(.x), "Setup should result in an X win")
+
+        let undoneMove = logic.undo()
+
+        #expect(undoneMove == MoveRecord(row: 0, col: 2, player: .x), "Undo should remove the winning move")
+        #expect(logic.gameState == .ongoing, "Undo should revert a terminal win back to ongoing")
+        #expect(logic.getWinningPatternCoordinates() == nil, "Winning coordinates should clear after undo")
+        #expect(logic.getPlayerAt(row: 0, col: 2) == nil, "Winning cell should be empty after undo")
+        #expect(logic.currentPlayer == .x, "Undo should give the winning player their turn back")
+    }
+
+    @Test("Undo reverts a draw back to an ongoing game")
+    func testUndoRevertsDrawState() {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+
+        let drawMoves: [(Int, Int)] = [
+            (0, 0), (0, 1), (0, 2), (1, 2),
+            (1, 0), (2, 0), (1, 1), (2, 2),
+            (2, 1)
+        ]
+        makeMoves(logic, moves: drawMoves)
+        #expect(logic.gameState == .draw, "Setup should result in a draw")
+
+        let undoneMove = logic.undo()
+
+        #expect(undoneMove == MoveRecord(row: 2, col: 1, player: .x), "Undo should remove the final draw move")
+        #expect(logic.gameState == .ongoing, "Undo should revert a draw back to ongoing")
+        #expect(logic.getPlayerAt(row: 2, col: 1) == nil, "Undo should clear the final draw move")
+        #expect(logic.currentPlayer == .x, "Undo should restore the drawing player")
+    }
+
+    @Test("Undo supports multiple consecutive moves")
+    func testUndoSupportsMultipleConsecutiveMoves() {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+
+        _ = logic.makeMove(row: 0, col: 0) // X
+        _ = logic.makeMove(row: 1, col: 1) // O
+        _ = logic.makeMove(row: 2, col: 2) // X
+
+        #expect(logic.undo() == MoveRecord(row: 2, col: 2, player: .x), "First undo should remove the most recent move")
+        #expect(logic.undo() == MoveRecord(row: 1, col: 1, player: .o), "Second undo should remove the next-most-recent move")
+        #expect(logic.getPlayerAt(row: 2, col: 2) == nil, "First undone cell should be empty")
+        #expect(logic.getPlayerAt(row: 1, col: 1) == nil, "Second undone cell should be empty")
+        #expect(logic.getPlayerAt(row: 0, col: 0) == .x, "The oldest move should remain")
+        #expect(logic.currentPlayer == .o, "Undo should restore the correct turn after multiple undos")
+        #expect(logic.canUndo == true, "Undo should remain available while one move is left")
+    }
+
      // MARK: - Getters Test
 
     @Test("GetPlayerAt and GetWinningPatternCoordinates Tests")
@@ -624,5 +726,91 @@ final class GameLogicTests {
         let snap = GameSnapshot(boardSize: 3, xBoard: 1 << 9, oBoard: 0, currentPlayer: .x, gameState: .ongoing)
         let restored = GameLogic.restored(from: snap)
         #expect(restored == nil, "Restore should fail when bitboard contains out-of-range bits")
+    }
+
+    // MARK: - Persistence Tests
+
+    @Test("GamePersistence saves and loads an in-progress game")
+    func testGamePersistenceRoundTrip() {
+        resetPersistenceStores()
+        defer { resetPersistenceStores() }
+
+        guard let logic = GameLogic(boardSize: 4) else {
+            #expect(Bool(false), "GameLogic should initialize successfully with size 4")
+            return
+        }
+
+        _ = logic.makeMove(row: 0, col: 0)
+        _ = logic.makeMove(row: 1, col: 1)
+
+        let persisted = PersistedGame(snapshot: logic.snapshot(), xWins: 2, oWins: 1, draws: 3)
+        GamePersistence.save(persisted)
+
+        let loaded = GamePersistence.load()
+        #expect(loaded == persisted, "Persistence should restore the same in-progress game")
+    }
+
+    @Test("GamePersistence ignores finished games and clears stored data")
+    func testGamePersistenceIgnoresCompletedGames() {
+        resetPersistenceStores()
+        defer { resetPersistenceStores() }
+
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+
+        makeMoves(logic, moves: [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2)])
+        let persisted = PersistedGame(snapshot: logic.snapshot(), xWins: 1, oWins: 0, draws: 0)
+        GamePersistence.save(persisted)
+
+        #expect(GamePersistence.load() == nil, "Completed games should not be restored")
+        #expect(
+            UserDefaults.standard.data(forKey: GamePersistence.storageKey) == nil,
+            "Completed games should be removed from storage"
+        )
+    }
+
+    @Test("GamePersistence clears corrupt payloads")
+    func testGamePersistenceClearsCorruptPayloads() {
+        resetPersistenceStores()
+        defer { resetPersistenceStores() }
+
+        UserDefaults.standard.set(Data("not-json".utf8), forKey: GamePersistence.storageKey)
+
+        #expect(GamePersistence.load() == nil, "Corrupt persisted games should fail to load")
+        #expect(
+            UserDefaults.standard.data(forKey: GamePersistence.storageKey) == nil,
+            "Corrupt persisted games should be removed from storage"
+        )
+    }
+
+    @Test("StatsStore records outcomes and rolls them back without going negative")
+    func testStatsStoreRecordAndRollback() {
+        resetPersistenceStores()
+        defer { resetPersistenceStores() }
+
+        StatsStore.recordWin(for: .x)
+        StatsStore.recordWin(for: .o)
+        StatsStore.recordDraw()
+
+        #expect(StatsStore.load() == LifetimeStats(xWins: 1, oWins: 1, draws: 1), "Recorded stats should round-trip")
+
+        StatsStore.rollBack(.won(.x))
+        StatsStore.rollBack(.won(.o))
+        StatsStore.rollBack(.draw)
+        StatsStore.rollBack(.draw)
+
+        #expect(StatsStore.load() == LifetimeStats(), "Rollbacks should never drive counts below zero")
+    }
+
+    @Test("StatsStore returns empty stats for corrupt data")
+    func testStatsStoreIgnoresCorruptData() {
+        resetPersistenceStores()
+        defer { resetPersistenceStores() }
+
+        UserDefaults.standard.set(Data("not-json".utf8), forKey: StatsStore.storageKey)
+
+        #expect(StatsStore.load() == LifetimeStats(), "Corrupt stats payloads should decode to empty stats")
     }
 }

--- a/TicTacToeTests/TicTacToeTests.swift
+++ b/TicTacToeTests/TicTacToeTests.swift
@@ -108,7 +108,7 @@ final class GameLogicTests {
         // Attempt the same move again
         let invalidMoveOutcome = logic.makeMove(row: 0, col: 0)
         // Use the specific failure enum case from MoveOutcome
-        #expect(invalidMoveOutcome == .failure_positionTaken, "Expected move on taken position to return .failure_positionTaken")
+        #expect(invalidMoveOutcome == .failurePositionTaken, "Expected move on taken position to return .failurePositionTaken")
         #expect(logic.getPlayerAt(row: 0, col: 0) == .x, "The player at (0,0) should still be X") // Verify state didn't change
     }
 
@@ -120,10 +120,10 @@ final class GameLogicTests {
          }
 
          let outcomeNegativeRow = logic.makeMove(row: -1, col: 0)
-         #expect(outcomeNegativeRow == .failure_invalidCoordinates, "Expected out of bounds move (negative row) to fail")
+         #expect(outcomeNegativeRow == .failureInvalidCoordinates, "Expected out of bounds move (negative row) to fail")
 
          let outcomeTooLargeCol = logic.makeMove(row: 0, col: logic.boardSize)
-          #expect(outcomeTooLargeCol == .failure_invalidCoordinates, "Expected out of bounds move (col too large) to fail")
+          #expect(outcomeTooLargeCol == .failureInvalidCoordinates, "Expected out of bounds move (col too large) to fail")
 
          #expect(logic.gameState == .ongoing, "Game state should remain ongoing after invalid moves")
          #expect(logic.currentPlayer == .x, "Current player should not change after invalid moves")
@@ -145,7 +145,7 @@ final class GameLogicTests {
         let moveAfterWinOutcome = logic.makeMove(row: 2, col: 2)
 
         // Use the specific failure enum case
-        #expect(moveAfterWinOutcome == .failure_gameAlreadyOver, "Expected move after game win to return .failure_gameAlreadyOver")
+        #expect(moveAfterWinOutcome == .failureGameAlreadyOver, "Expected move after game win to return .failureGameAlreadyOver")
          #expect(logic.getPlayerAt(row: 2, col: 2) == nil, "Cell should remain empty after failed move on game over")
     }
 
@@ -458,5 +458,171 @@ final class GameLogicTests {
         #expect(logic != nil, "GameLogic should initialize with size 7 (49 < 64)")
         #expect(logic?.boardSize == 7)
         #expect(logic?.gameState == .ongoing)
+    }
+
+    // MARK: - Snapshot / Restore Tests
+
+    @Test("Snapshot round-trip preserves board, current player, and state for ongoing game")
+    func testSnapshotRoundTripOngoing() throws {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+        // X: (0,0), O: (1,1), X: (0,1)
+        _ = logic.makeMove(row: 0, col: 0)
+        _ = logic.makeMove(row: 1, col: 1)
+        _ = logic.makeMove(row: 0, col: 1)
+
+        let snap = logic.snapshot()
+        guard let restored = GameLogic.restored(from: snap) else {
+            #expect(Bool(false), "GameLogic should restore from a valid snapshot")
+            return
+        }
+
+        #expect(restored.boardSize == logic.boardSize, "boardSize should match after round-trip")
+        #expect(restored.gameState == .ongoing, "gameState should be ongoing after round-trip")
+        #expect(restored.currentPlayer == logic.currentPlayer, "currentPlayer should match after round-trip")
+
+        for r in 0..<logic.boardSize {
+            for c in 0..<logic.boardSize {
+                #expect(
+                    restored.getPlayerAt(row: r, col: c) == logic.getPlayerAt(row: r, col: c),
+                    "Cell (\(r),\(c)) should match after round-trip"
+                )
+            }
+        }
+    }
+
+    @Test("Snapshot round-trip preserves won state and winning coordinates")
+    func testSnapshotRoundTripWon() throws {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+        // Drive X to win the top row: X(0,0) O(1,0) X(0,1) O(1,1) X(0,2)
+        _ = logic.makeMove(row: 0, col: 0)
+        _ = logic.makeMove(row: 1, col: 0)
+        _ = logic.makeMove(row: 0, col: 1)
+        _ = logic.makeMove(row: 1, col: 1)
+        _ = logic.makeMove(row: 0, col: 2)
+
+        #expect(logic.gameState == .won(.x), "Setup should result in X winning")
+
+        let snap = logic.snapshot()
+        guard let restored = GameLogic.restored(from: snap) else {
+            #expect(Bool(false), "GameLogic should restore from a won-state snapshot")
+            return
+        }
+
+        #expect(restored.gameState == .won(.x), "Restored game should show X winning")
+        let coords = restored.getWinningPatternCoordinates()
+        #expect(coords != nil, "Winning coordinates should be available after restore")
+        #expect(coords?.count == 3, "Should have 3 winning coordinates")
+        let expected: Set<String> = ["0,0", "0,1", "0,2"]
+        if let coords {
+            #expect(Set(coords.map { "\($0.row),\($0.col)" }) == expected, "Winning row 0 should be restored")
+        }
+    }
+
+    @Test("Snapshot round-trip preserves draw state")
+    func testSnapshotRoundTripDraw() throws {
+        guard let logic = GameLogic(boardSize: 3) else {
+            #expect(Bool(false), "GameLogic should initialize successfully")
+            return
+        }
+        // Draw sequence on a 3x3 — produces:
+        // X O X
+        // X X O
+        // O X O
+        let drawMoves: [(Int, Int)] = [
+            (0, 0), (0, 1), (0, 2), (1, 2),
+            (1, 0), (2, 0), (1, 1), (2, 2),
+            (2, 1)
+        ]
+        makeMoves(logic, moves: drawMoves)
+        #expect(logic.gameState == .draw, "Setup should result in a draw")
+
+        let snap = logic.snapshot()
+        guard let restored = GameLogic.restored(from: snap) else {
+            #expect(Bool(false), "GameLogic should restore from a draw-state snapshot")
+            return
+        }
+
+        #expect(restored.gameState == .draw, "Restored game should show draw")
+        for r in 0..<logic.boardSize {
+            for c in 0..<logic.boardSize {
+                #expect(
+                    restored.getPlayerAt(row: r, col: c) == logic.getPlayerAt(row: r, col: c),
+                    "Cell (\(r),\(c)) should match after draw round-trip"
+                )
+            }
+        }
+    }
+
+    @Test("Snapshot round-trip works for 4x4 board")
+    func testSnapshotRoundTrip4x4() throws {
+        guard let logic = GameLogic(boardSize: 4) else {
+            #expect(Bool(false), "GameLogic should initialize successfully with size 4")
+            return
+        }
+        _ = logic.makeMove(row: 0, col: 0) // X
+        _ = logic.makeMove(row: 3, col: 3) // O
+        _ = logic.makeMove(row: 2, col: 1) // X
+
+        let snap = logic.snapshot()
+        guard let restored = GameLogic.restored(from: snap) else {
+            #expect(Bool(false), "GameLogic should restore from a 4x4 snapshot")
+            return
+        }
+
+        #expect(restored.boardSize == 4, "boardSize should be 4 after round-trip")
+        #expect(restored.gameState == .ongoing, "gameState should be ongoing")
+        #expect(restored.currentPlayer == logic.currentPlayer, "currentPlayer should match")
+        for r in 0..<4 {
+            for c in 0..<4 {
+                #expect(
+                    restored.getPlayerAt(row: r, col: c) == logic.getPlayerAt(row: r, col: c),
+                    "Cell (\(r),\(c)) should match on 4x4 after round-trip"
+                )
+            }
+        }
+    }
+
+    @Test("Snapshot restore returns nil for invalid board size")
+    func testSnapshotRestoreFailsForInvalidBoardSize() {
+        let snap = GameSnapshot(boardSize: 0, xBoard: 0, oBoard: 0, currentPlayer: .x, gameState: .ongoing)
+        let restored = GameLogic.restored(from: snap)
+        #expect(restored == nil, "Restore should fail for boardSize 0")
+    }
+
+    @Test("Snapshot restore returns nil for xBoard with high bits (negative when cast to Int)")
+    func testSnapshotRestoreFailsForHighBitXBoard() {
+        // UInt64.max converts to Int(-1) — rejected by the >= 0 guard
+        let snap = GameSnapshot(boardSize: 3, xBoard: .max, oBoard: 0, currentPlayer: .x, gameState: .ongoing)
+        let restored = GameLogic.restored(from: snap)
+        #expect(restored == nil, "Restore should fail when xBoard overflows to negative Int")
+    }
+
+    @Test("Snapshot restore returns nil for oBoard with high bits (negative when cast to Int)")
+    func testSnapshotRestoreFailsForHighBitOBoard() {
+        let snap = GameSnapshot(boardSize: 3, xBoard: 0, oBoard: .max, currentPlayer: .x, gameState: .ongoing)
+        let restored = GameLogic.restored(from: snap)
+        #expect(restored == nil, "Restore should fail when oBoard overflows to negative Int")
+    }
+
+    @Test("Snapshot restore returns nil for overlapping bitboards")
+    func testSnapshotRestoreFailsForOverlappingBitboards() {
+        // Both boards claim bit 0 (cell 0,0)
+        let snap = GameSnapshot(boardSize: 3, xBoard: 1, oBoard: 1, currentPlayer: .o, gameState: .ongoing)
+        let restored = GameLogic.restored(from: snap)
+        #expect(restored == nil, "Restore should fail when xBoard and oBoard overlap")
+    }
+
+    @Test("Snapshot restore returns nil for out-of-range bits")
+    func testSnapshotRestoreFailsForOutOfRangeBits() {
+        // Bit 9 is outside a 3x3 board mask (0b111111111 = 511)
+        let snap = GameSnapshot(boardSize: 3, xBoard: 1 << 9, oBoard: 0, currentPlayer: .x, gameState: .ongoing)
+        let restored = GameLogic.restored(from: snap)
+        #expect(restored == nil, "Restore should fail when bitboard contains out-of-range bits")
     }
 }

--- a/tictactoe Shared/GameLogic.swift
+++ b/tictactoe Shared/GameLogic.swift
@@ -195,8 +195,28 @@ public final class GameLogic {
     /// - Returns: `nil` if the snapshot's board size is invalid.
     public convenience init?(snapshot: GameSnapshot) {
         self.init(boardSize: snapshot.boardSize)
-        self.xBoard = snapshot.xBoard
-        self.oBoard = snapshot.oBoard
+
+        let validMask = fullBoardMask
+        let xBoard = snapshot.xBoard
+        let oBoard = snapshot.oBoard
+
+        guard xBoard >= 0, oBoard >= 0 else {
+            Self.log.error("Failed to restore snapshot: negative bitboard value")
+            return nil
+        }
+
+        guard (xBoard & oBoard) == 0 else {
+            Self.log.error("Failed to restore snapshot: overlapping bitboards")
+            return nil
+        }
+
+        guard ((xBoard | oBoard) & ~validMask) == 0 else {
+            Self.log.error("Failed to restore snapshot: bitboard contains out-of-range bits")
+            return nil
+        }
+
+        self.xBoard = xBoard
+        self.oBoard = oBoard
         self.currentPlayer = snapshot.currentPlayer
         self.gameState = snapshot.gameState
         // Recompute the winning pattern so `getWinningPatternCoordinates()`

--- a/tictactoe Shared/GameLogic.swift
+++ b/tictactoe Shared/GameLogic.swift
@@ -3,7 +3,7 @@ import os
 
 // MARK: - Player
 
-public enum Player: Int, CaseIterable, Sendable {
+public enum Player: Int, CaseIterable, Sendable, Codable {
     case x = 1, o
     public var symbol: String { rawValue == 1 ? "❌" : "⭕" }
     public var next: Player { self == .x ? .o : .x }
@@ -11,10 +11,36 @@ public enum Player: Int, CaseIterable, Sendable {
 
 // MARK: - GameState
 
-public enum GameState: Equatable, Sendable {
+public enum GameState: Equatable, Sendable, Codable {
     case ongoing
     case won(Player)
     case draw
+}
+
+// MARK: - GameSnapshot
+
+/// A serializable snapshot of a `GameLogic` instance — sufficient to
+/// reconstruct the full logical state (board, current player, game state).
+public struct GameSnapshot: Codable, Sendable, Equatable {
+    public let boardSize: Int
+    public let xBoard: Int
+    public let oBoard: Int
+    public let currentPlayer: Player
+    public let gameState: GameState
+
+    public init(
+        boardSize: Int,
+        xBoard: Int,
+        oBoard: Int,
+        currentPlayer: Player,
+        gameState: GameState
+    ) {
+        self.boardSize = boardSize
+        self.xBoard = xBoard
+        self.oBoard = oBoard
+        self.currentPlayer = currentPlayer
+        self.gameState = gameState
+    }
 }
 
 // MARK: - MoveOutcome
@@ -151,6 +177,35 @@ public final class GameLogic {
 
     /// Subscript access to `getPlayerAt(row:col:)`.
     public subscript(row: Int, col: Int) -> Player? { getPlayerAt(row: row, col: col) }
+
+    // MARK: - Snapshot / Restore
+
+    /// Captures the current logical state in a serializable snapshot.
+    public func snapshot() -> GameSnapshot {
+        GameSnapshot(
+            boardSize: boardSize,
+            xBoard: xBoard,
+            oBoard: oBoard,
+            currentPlayer: currentPlayer,
+            gameState: gameState
+        )
+    }
+
+    /// Creates a new `GameLogic` restored from a previously captured snapshot.
+    /// - Returns: `nil` if the snapshot's board size is invalid.
+    public convenience init?(snapshot: GameSnapshot) {
+        self.init(boardSize: snapshot.boardSize)
+        self.xBoard = snapshot.xBoard
+        self.oBoard = snapshot.oBoard
+        self.currentPlayer = snapshot.currentPlayer
+        self.gameState = snapshot.gameState
+        // Recompute the winning pattern so `getWinningPatternCoordinates()`
+        // behaves correctly for a restored won state.
+        if case .won(let winner) = snapshot.gameState {
+            _ = checkWin(for: winner == .x ? xBoard : oBoard)
+        }
+        Self.log.info("GameLogic restored from snapshot boardSize=\(self.boardSize)")
+    }
 
     // MARK: - Private Helpers
 

--- a/tictactoe Shared/GameLogic.swift
+++ b/tictactoe Shared/GameLogic.swift
@@ -3,7 +3,7 @@ import os
 
 // MARK: - Player
 
-public enum Player: Int, CaseIterable, Sendable {
+public enum Player: Int, CaseIterable, Sendable, Codable {
     case x = 1, o
     public var symbol: String { rawValue == 1 ? "❌" : "⭕" }
     public var next: Player { self == .x ? .o : .x }
@@ -11,19 +11,66 @@ public enum Player: Int, CaseIterable, Sendable {
 
 // MARK: - GameState
 
-public enum GameState: Equatable, Sendable {
+public enum GameState: Equatable, Sendable, Codable {
     case ongoing
     case won(Player)
     case draw
+}
+
+// MARK: - GameSnapshot
+
+/// A serializable snapshot of a `GameLogic` instance — sufficient to
+/// reconstruct the full logical state (board, current player, game state,
+/// and undo history).
+public struct GameSnapshot: Codable, Sendable, Equatable {
+    public let boardSize: Int
+    /// Bitboard for X pieces, stored as `UInt64` for portable serialization.
+    public let xBoard: UInt64
+    /// Bitboard for O pieces, stored as `UInt64` for portable serialization.
+    public let oBoard: UInt64
+    public let currentPlayer: Player
+    public let gameState: GameState
+    public let moveHistory: [MoveRecord]
+
+    public init(
+        boardSize: Int,
+        xBoard: UInt64,
+        oBoard: UInt64,
+        currentPlayer: Player,
+        gameState: GameState,
+        moveHistory: [MoveRecord] = []
+    ) {
+        self.boardSize = boardSize
+        self.xBoard = xBoard
+        self.oBoard = oBoard
+        self.currentPlayer = currentPlayer
+        self.gameState = gameState
+        self.moveHistory = moveHistory
+    }
+}
+
+// MARK: - MoveRecord
+
+/// A completed move, in the order it was played.
+public struct MoveRecord: Codable, Sendable, Equatable {
+    public let row: Int
+    public let col: Int
+    public let player: Player
+
+    public init(row: Int, col: Int, player: Player) {
+        self.row = row
+        self.col = col
+        self.player = player
+    }
 }
 
 // MARK: - MoveOutcome
 
 public enum MoveOutcome: Equatable, Sendable {
     case success
-    case failure_positionTaken
-    case failure_invalidCoordinates
-    case failure_gameAlreadyOver
+    case failurePositionTaken
+    case failureInvalidCoordinates
+    case failureGameAlreadyOver
 }
 
 // MARK: - GameLogic
@@ -57,10 +104,12 @@ public final class GameLogic {
     private var oBoard = 0
     private var winningPattern: Int?
     private let fullBoardMask: Int
+    private var moveHistory: [MoveRecord] = []
 
     /// Winning-pattern cache shared across all instances.
     /// Populated once per board size; never mutated after insertion.
-    nonisolated(unsafe) private static var cachedWinningPatterns: [Int: [Int]] = [:]
+    /// Safe because the class (and thus this static) is `@MainActor`-isolated.
+    private static var cachedWinningPatterns: [Int: [Int]] = [:]
 
     // MARK: - Init
 
@@ -92,30 +141,32 @@ public final class GameLogic {
 
         guard row >= 0, row < boardSize, col >= 0, col < boardSize else {
             Self.log.info("Move failed: (\(row), \(col)) out of bounds")
-            return .failure_invalidCoordinates
+            return .failureInvalidCoordinates
         }
         guard gameState == .ongoing else {
             Self.log.info("Move failed: game already over (\(String(describing: self.gameState)))")
-            return .failure_gameAlreadyOver
+            return .failureGameAlreadyOver
         }
 
         let moveBit = positionToBit(row: row, col: col)
         guard (xBoard | oBoard) & moveBit == 0 else {
             Self.log.info("Move failed: (\(row), \(col)) already taken")
-            return .failure_positionTaken
+            return .failurePositionTaken
         }
 
         if currentPlayer == .x { xBoard |= moveBit } else { oBoard |= moveBit }
+        let mover = currentPlayer
+        moveHistory.append(MoveRecord(row: row, col: col, player: mover))
 
-        let playerBoard = currentPlayer == .x ? xBoard : oBoard
+        let playerBoard = mover == .x ? xBoard : oBoard
         if checkWin(for: playerBoard) {
-            gameState = .won(currentPlayer)
-            Self.log.info("Game won by \(self.currentPlayer.symbol)")
+            gameState = .won(mover)
+            Self.log.info("Game won by \(mover.symbol)")
         } else if checkDraw() {
             gameState = .draw
             Self.log.info("Game draw")
         } else {
-            currentPlayer = currentPlayer.next
+            currentPlayer = mover.next
             Self.log.debug("Next player: \(self.currentPlayer.symbol)")
         }
         return .success
@@ -128,7 +179,29 @@ public final class GameLogic {
         currentPlayer = .x
         gameState = .ongoing
         winningPattern = nil
+        moveHistory.removeAll()
         Self.log.info("Game reset boardSize=\(self.boardSize)")
+    }
+
+    /// Whether there's at least one move that can be undone.
+    public var canUndo: Bool { !moveHistory.isEmpty }
+
+    /// Undoes the last move. If the game had ended, reverts it to `.ongoing`.
+    /// - Returns: The move that was undone, or `nil` if there were no moves.
+    @discardableResult
+    public func undo() -> MoveRecord? {
+        guard let last = moveHistory.popLast() else { return nil }
+        let bit = positionToBit(row: last.row, col: last.col)
+        if last.player == .x {
+            xBoard &= ~bit
+        } else {
+            oBoard &= ~bit
+        }
+        currentPlayer = last.player
+        gameState = .ongoing
+        winningPattern = nil
+        Self.log.info("Undo \(last.player.symbol) at (\(last.row), \(last.col))")
+        return last
     }
 
     /// Returns the winning line coordinates when the game is won.
@@ -151,6 +224,64 @@ public final class GameLogic {
 
     /// Subscript access to `getPlayerAt(row:col:)`.
     public subscript(row: Int, col: Int) -> Player? { getPlayerAt(row: row, col: col) }
+
+    // MARK: - Snapshot / Restore
+
+    /// Captures the current logical state in a serializable snapshot.
+    public func snapshot() -> GameSnapshot {
+        GameSnapshot(
+            boardSize: boardSize,
+            xBoard: UInt64(bitPattern: Int64(xBoard)),
+            oBoard: UInt64(bitPattern: Int64(oBoard)),
+            currentPlayer: currentPlayer,
+            gameState: gameState,
+            moveHistory: moveHistory
+        )
+    }
+
+    /// Restores a `GameLogic` from a previously captured snapshot.
+    ///
+    /// Validates that bitboards don't overlap, fit within the board, and that
+    /// the move history length matches the number of placed pieces.
+    /// - Returns: `nil` if the snapshot is invalid or corrupt.
+    public static func restored(from snapshot: GameSnapshot) -> GameLogic? {
+        guard let instance = GameLogic(boardSize: snapshot.boardSize) else { return nil }
+
+        let xBoard = Int(Int64(bitPattern: snapshot.xBoard))
+        let oBoard = Int(Int64(bitPattern: snapshot.oBoard))
+        let validMask = instance.fullBoardMask
+
+        guard xBoard >= 0, oBoard >= 0 else {
+            log.error("Snapshot rejected: negative bitboard value")
+            return nil
+        }
+        guard (xBoard & oBoard) == 0 else {
+            log.error("Snapshot rejected: overlapping bitboards")
+            return nil
+        }
+        guard ((xBoard | oBoard) & ~validMask) == 0 else {
+            log.error("Snapshot rejected: bits outside valid board mask")
+            return nil
+        }
+
+        let pieceCount = xBoard.nonzeroBitCount + oBoard.nonzeroBitCount
+        guard snapshot.moveHistory.count == pieceCount else {
+            log.error("Snapshot rejected: moveHistory count (\(snapshot.moveHistory.count)) != piece count (\(pieceCount))")
+            return nil
+        }
+
+        instance.xBoard = xBoard
+        instance.oBoard = oBoard
+        instance.currentPlayer = snapshot.currentPlayer
+        instance.gameState = snapshot.gameState
+        instance.moveHistory = snapshot.moveHistory
+
+        if case .won(let winner) = snapshot.gameState {
+            _ = instance.checkWin(for: winner == .x ? xBoard : oBoard)
+        }
+        log.info("GameLogic restored from snapshot boardSize=\(instance.boardSize)")
+        return instance
+    }
 
     // MARK: - Private Helpers
 

--- a/tictactoe Shared/GameLogic.swift
+++ b/tictactoe Shared/GameLogic.swift
@@ -207,10 +207,15 @@ public final class GameLogic {
     /// Returns the winning line coordinates when the game is won.
     public func getWinningPatternCoordinates() -> [(row: Int, col: Int)]? {
         guard case .won = gameState, let pattern = winningPattern else { return nil }
-        return (0..<boardSize * boardSize)
-            .filter { (pattern & (1 << $0)) != 0 }
-            .map { ($0 / boardSize, $0 % boardSize) }
-            .sorted { $0.0 * boardSize + $0.1 < $1.0 * boardSize + $1.1 }
+        let totalCells = boardSize * boardSize
+        var coordinates: [(row: Int, col: Int)] = []
+        coordinates.reserveCapacity(boardSize)
+
+        for position in 0..<totalCells where (pattern & (1 << position)) != 0 {
+            coordinates.append((row: position / boardSize, col: position % boardSize))
+        }
+
+        return coordinates
     }
 
     /// Returns the player at the given board position, or `nil` if empty / out of bounds.
@@ -312,4 +317,3 @@ public final class GameLogic {
         (xBoard | oBoard) == fullBoardMask
     }
 }
-

--- a/tictactoe Shared/GamePersistence.swift
+++ b/tictactoe Shared/GamePersistence.swift
@@ -1,0 +1,83 @@
+import Foundation
+import os
+
+// MARK: - PersistedGame
+
+/// A persisted, in-progress game: the logical snapshot plus the session scores
+/// that belong to the scene that owned it.
+public struct PersistedGame: Codable, Sendable, Equatable {
+    public let snapshot: GameSnapshot
+    public let xWins: Int
+    public let oWins: Int
+    public let draws: Int
+
+    public init(snapshot: GameSnapshot, xWins: Int, oWins: Int, draws: Int) {
+        self.snapshot = snapshot
+        self.xWins = xWins
+        self.oWins = oWins
+        self.draws = draws
+    }
+
+    /// True when the snapshot represents an in-progress game that should be
+    /// restored on relaunch (bypassing the main menu).
+    public var isInProgress: Bool {
+        snapshot.gameState == .ongoing
+    }
+}
+
+// MARK: - GamePersistence
+
+/// Lightweight `UserDefaults`-backed persistence for an in-progress game.
+///
+/// The app saves after every move and clears on game over / return-to-menu.
+/// On relaunch, a non-nil `load()` signals the view controller to skip the
+/// main menu and jump straight back into the ongoing game.
+public enum GamePersistence {
+
+    public static let storageKey = "com.cascadiacollections.tictactoe.persistedGame.v1"
+
+    private static let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.cascadiacollections.tictactoe",
+        category: "GamePersistence"
+    )
+
+    private static let defaults: UserDefaults = .standard
+
+    /// Saves the given persisted game. No-op if encoding fails.
+    public static func save(_ game: PersistedGame) {
+        do {
+            let data = try JSONEncoder().encode(game)
+            defaults.set(data, forKey: storageKey)
+            log.debug("Persisted game saved (\(data.count) bytes)")
+        } catch {
+            log.error("Failed to encode persisted game: \(error.localizedDescription)")
+        }
+    }
+
+    /// Loads a previously persisted in-progress game, if any.
+    ///
+    /// Returns `nil` if nothing was saved, the payload is corrupt, or the
+    /// saved game is no longer in progress (won / drawn).
+    public static func load() -> PersistedGame? {
+        guard let data = defaults.data(forKey: storageKey) else { return nil }
+        do {
+            let game = try JSONDecoder().decode(PersistedGame.self, from: data)
+            guard game.isInProgress else {
+                log.debug("Stored game is not in progress — ignoring")
+                clear()
+                return nil
+            }
+            return game
+        } catch {
+            log.error("Failed to decode persisted game: \(error.localizedDescription)")
+            clear()
+            return nil
+        }
+    }
+
+    /// Removes any previously saved game.
+    public static func clear() {
+        defaults.removeObject(forKey: storageKey)
+        log.debug("Persisted game cleared")
+    }
+}

--- a/tictactoe Shared/GamePersistence.swift
+++ b/tictactoe Shared/GamePersistence.swift
@@ -1,0 +1,168 @@
+import Foundation
+import os
+
+// MARK: - PersistedGame
+
+/// A persisted, in-progress game: the logical snapshot plus the session scores
+/// that belong to the scene that owned it.
+public struct PersistedGame: Codable, Sendable, Equatable {
+    public let snapshot: GameSnapshot
+    public let xWins: Int
+    public let oWins: Int
+    public let draws: Int
+
+    public init(snapshot: GameSnapshot, xWins: Int, oWins: Int, draws: Int) {
+        self.snapshot = snapshot
+        self.xWins = xWins
+        self.oWins = oWins
+        self.draws = draws
+    }
+
+    /// True when the snapshot represents an in-progress game that should be
+    /// restored on relaunch (bypassing the main menu).
+    public var isInProgress: Bool {
+        snapshot.gameState == .ongoing
+    }
+}
+
+// MARK: - LifetimeStats
+
+/// Cumulative wins / draws counted across every game ever played on the
+/// device. Kept separate from the per-scene session scores.
+public struct LifetimeStats: Codable, Sendable, Equatable {
+    public var xWins: Int
+    public var oWins: Int
+    public var draws: Int
+
+    public init(xWins: Int = 0, oWins: Int = 0, draws: Int = 0) {
+        self.xWins = xWins
+        self.oWins = oWins
+        self.draws = draws
+    }
+
+    public var totalGames: Int { xWins + oWins + draws }
+}
+
+// MARK: - StatsStore
+
+/// `UserDefaults`-backed persistence for lifetime game stats.
+@MainActor
+public enum StatsStore {
+
+    public static let storageKey = "com.cascadiacollections.tictactoe.lifetimeStats.v1"
+
+    private static let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.cascadiacollections.tictactoe",
+        category: "StatsStore"
+    )
+
+    private static let defaults: UserDefaults = .standard
+
+    /// Loads the stored lifetime stats, or an empty record if none exist.
+    public static func load() -> LifetimeStats {
+        guard let data = defaults.data(forKey: storageKey) else { return .init() }
+        do {
+            return try JSONDecoder().decode(LifetimeStats.self, from: data)
+        } catch {
+            log.error("Failed to decode lifetime stats: \(error.localizedDescription)")
+            return .init()
+        }
+    }
+
+    public static func save(_ stats: LifetimeStats) {
+        do {
+            let data = try JSONEncoder().encode(stats)
+            defaults.set(data, forKey: storageKey)
+        } catch {
+            log.error("Failed to encode lifetime stats: \(error.localizedDescription)")
+        }
+    }
+
+    public static func recordWin(for player: Player) {
+        var stats = load()
+        if player == .x { stats.xWins += 1 } else { stats.oWins += 1 }
+        save(stats)
+    }
+
+    public static func recordDraw() {
+        var stats = load()
+        stats.draws += 1
+        save(stats)
+    }
+
+    /// Rolls back a previously-recorded outcome (used when a winning/draw move
+    /// is undone). Counters never go below zero.
+    public static func rollBack(_ state: GameState) {
+        var stats = load()
+        switch state {
+        case .won(.x): stats.xWins = max(0, stats.xWins - 1)
+        case .won(.o): stats.oWins = max(0, stats.oWins - 1)
+        case .draw:    stats.draws = max(0, stats.draws - 1)
+        case .ongoing: return
+        }
+        save(stats)
+    }
+
+    public static func reset() {
+        defaults.removeObject(forKey: storageKey)
+        log.info("Lifetime stats cleared")
+    }
+}
+
+// MARK: - GamePersistence
+
+/// Lightweight `UserDefaults`-backed persistence for an in-progress game.
+///
+/// The app saves after every move and clears on game over / return-to-menu.
+/// On relaunch, a non-nil `load()` signals the view controller to skip the
+/// main menu and jump straight back into the ongoing game.
+@MainActor
+public enum GamePersistence {
+
+    public static let storageKey = "com.cascadiacollections.tictactoe.persistedGame.v1"
+
+    private static let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.cascadiacollections.tictactoe",
+        category: "GamePersistence"
+    )
+
+    private static let defaults: UserDefaults = .standard
+
+    /// Saves the given persisted game. No-op if encoding fails.
+    public static func save(_ game: PersistedGame) {
+        do {
+            let data = try JSONEncoder().encode(game)
+            defaults.set(data, forKey: storageKey)
+            log.debug("Persisted game saved (\(data.count) bytes)")
+        } catch {
+            log.error("Failed to encode persisted game: \(error.localizedDescription)")
+        }
+    }
+
+    /// Loads a previously persisted in-progress game, if any.
+    ///
+    /// Returns `nil` if nothing was saved, the payload is corrupt, or the
+    /// saved game is no longer in progress (won / drawn).
+    public static func load() -> PersistedGame? {
+        guard let data = defaults.data(forKey: storageKey) else { return nil }
+        do {
+            let game = try JSONDecoder().decode(PersistedGame.self, from: data)
+            guard game.isInProgress else {
+                log.debug("Stored game is not in progress — ignoring")
+                clear()
+                return nil
+            }
+            return game
+        } catch {
+            log.error("Failed to decode persisted game: \(error.localizedDescription)")
+            clear()
+            return nil
+        }
+    }
+
+    /// Removes any previously saved game.
+    public static func clear() {
+        defaults.removeObject(forKey: storageKey)
+        log.debug("Persisted game cleared")
+    }
+}

--- a/tictactoe Shared/GameScene.swift
+++ b/tictactoe Shared/GameScene.swift
@@ -47,6 +47,7 @@ class GameScene: SKScene {
     // HUD nodes
     private var turnIndicatorLabel: SKLabelNode?
     private var scoreLabel: SKLabelNode?
+    private var menuButtonNode: SKNode?
 
     private static let log = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.cascadiacollections.tictactoe",
@@ -55,7 +56,7 @@ class GameScene: SKScene {
 
     // MARK: - Initialization
 
-    init?(boardSize: Int = 3, size: CGSize) {
+    init?(size: CGSize, boardSize: Int = 3) {
         guard let logic = GameLogic(boardSize: boardSize) else {
             Self.log.error("Failed to init GameLogic for boardSize=\(boardSize)")
             return nil
@@ -63,9 +64,23 @@ class GameScene: SKScene {
         self.boardSize = boardSize
         self.gameLogic = logic
         super.init(size: size)
-        anchorPoint = CGPoint(x: 0.5, y: 0.5)
-        scaleMode = .aspectFill
-        backgroundColor = .clear
+        applySceneDefaults()
+    }
+
+    /// Creates a scene that restores a previously persisted in-progress game,
+    /// including its session scores.
+    init?(size: CGSize, restoring persisted: PersistedGame) {
+        guard let logic = GameLogic(snapshot: persisted.snapshot) else {
+            Self.log.error("Failed to restore GameLogic from snapshot")
+            return nil
+        }
+        self.boardSize = logic.boardSize
+        self.gameLogic = logic
+        super.init(size: size)
+        self.xWins = persisted.xWins
+        self.oWins = persisted.oWins
+        self.draws = persisted.draws
+        applySceneDefaults()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -76,6 +91,12 @@ class GameScene: SKScene {
         boardSize = logic.boardSize
         gameLogic = logic
         super.init(coder: aDecoder)
+    }
+
+    private func applySceneDefaults() {
+        anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        scaleMode = .aspectFill
+        backgroundColor = .clear
     }
 
     // MARK: - Scene Lifecycle
@@ -96,6 +117,7 @@ class GameScene: SKScene {
         children.forEach { $0.removeFromParent() }
         turnIndicatorLabel = nil
         scoreLabel = nil
+        menuButtonNode = nil
 
         boardNode = SKNode()
         boardNode.alpha = 0
@@ -104,9 +126,22 @@ class GameScene: SKScene {
         calculateBoardLayout()
         cellNodes = Array(repeating: Array(repeating: nil, count: boardSize), count: boardSize)
         drawBoardGrid()
+        renderExistingMoves()
         setupHUD()
 
         boardNode.run(.fadeIn(withDuration: 0.3))
+    }
+
+    /// Renders any pieces already placed in the underlying `gameLogic`.
+    /// Used when the scene is restored from a persisted snapshot.
+    private func renderExistingMoves() {
+        for row in 0..<boardSize {
+            for col in 0..<boardSize {
+                if let player = gameLogic.getPlayerAt(row: row, col: col) {
+                    updateTile(row: row, col: col, player: player, animated: false)
+                }
+            }
+        }
     }
 
     private func calculateBoardLayout() {
@@ -157,7 +192,47 @@ class GameScene: SKScene {
         addChild(score)
         scoreLabel = score
 
+        setupMenuButton(boardDim: boardDim)
+
         updateHUD()
+    }
+
+    private func setupMenuButton(boardDim: CGFloat) {
+        let buttonWidth = cellSize * 1.35
+        let buttonHeight = cellSize * 0.48
+
+        let container = SKNode()
+        container.name = "menuButton"
+        container.zPosition = 6
+        container.position = CGPoint(
+            x: -boardDim / 2 + buttonWidth / 2,
+            y: boardDim / 2 + cellSize * 0.42
+        )
+
+        let bg = SKShapeNode(
+            rect: CGRect(
+                x: -buttonWidth / 2,
+                y: -buttonHeight / 2,
+                width: buttonWidth,
+                height: buttonHeight
+            ),
+            cornerRadius: buttonHeight * 0.3
+        )
+        bg.fillColor = GameColor.systemGray6
+        bg.strokeColor = GameColor.systemGray3
+        bg.lineWidth = 1.5
+        container.addChild(bg)
+
+        let label = SKLabelNode(text: "≡ Menu")
+        label.fontName = "HelveticaNeue-Medium"
+        label.fontSize = buttonHeight * 0.45
+        label.fontColor = GameColor.label
+        label.verticalAlignmentMode = .center
+        label.horizontalAlignmentMode = .center
+        container.addChild(label)
+
+        addChild(container)
+        menuButtonNode = container
     }
 
     private func updateHUD() {
@@ -207,6 +282,13 @@ class GameScene: SKScene {
 
     private func handleInteraction(at location: CGPoint) {
         guard !isResetting else { return }
+
+        // Menu button takes precedence over any other interaction.
+        if let menu = menuButtonNode, menu.calculateAccumulatedFrame().contains(location) {
+            returnToMainMenu()
+            return
+        }
+
         if isGameOver { resetGame(); return }
         guard let (row, col) = cellCoordinates(from: location) else { return }
         let mover = gameLogic.currentPlayer
@@ -215,6 +297,7 @@ class GameScene: SKScene {
             Self.log.info("Move \(mover.symbol) at (\(row), \(col))")
             updateTile(row: row, col: col, player: mover)
             checkGameState()
+            persistCurrentState()
         case .failure_positionTaken:
             Self.log.debug("Cell (\(row), \(col)) already taken")
             animateCellShake(row: row, col: col)
@@ -225,9 +308,39 @@ class GameScene: SKScene {
         }
     }
 
+    // MARK: - Persistence
+
+    /// Saves the current logical state when a game is in progress; clears the
+    /// persisted slot once the game has ended so the next launch returns to
+    /// the main menu.
+    private func persistCurrentState() {
+        guard gameLogic.gameState == .ongoing else {
+            GamePersistence.clear()
+            return
+        }
+        let persisted = PersistedGame(
+            snapshot: gameLogic.snapshot(),
+            xWins: xWins,
+            oWins: oWins,
+            draws: draws
+        )
+        GamePersistence.save(persisted)
+    }
+
+    // MARK: - Navigation
+
+    private func returnToMainMenu() {
+        Self.log.info("Returning to main menu")
+        GamePersistence.clear()
+        guard let view else { return }
+        let menu = MainMenuScene(size: view.bounds.size)
+        menu.scaleMode = .aspectFill
+        view.presentScene(menu, transition: .fade(withDuration: 0.25))
+    }
+
     // MARK: - Rendering
 
-    private func updateTile(row: Int, col: Int, player: Player) {
+    private func updateTile(row: Int, col: Int, player: Player, animated: Bool = true) {
         guard let cellOpt = cellNodes[safe: row]?[safe: col],
               let cell = cellOpt else { return }
         let label = SKLabelNode(text: player == .x ? "X" : "O")
@@ -236,12 +349,14 @@ class GameScene: SKScene {
         label.fontName = "HelveticaNeue-Bold"
         label.verticalAlignmentMode = .center
         label.horizontalAlignmentMode = .center
-        label.setScale(0)
+        label.setScale(animated ? 0 : 1)
         cell.addChild(label)
-        label.run(.sequence([
-            .scale(to: 1.2, duration: 0.10),
-            .scale(to: 1.0, duration: 0.08)
-        ]))
+        if animated {
+            label.run(.sequence([
+                .scale(to: 1.2, duration: 0.10),
+                .scale(to: 1.0, duration: 0.08)
+            ]))
+        }
     }
 
     private func checkGameState() {
@@ -348,6 +463,8 @@ class GameScene: SKScene {
         isResetting = true
 
         gameLogic.reset()
+        // Starting a fresh round — nothing to restore until the next move.
+        GamePersistence.clear()
 
         childNode(withName: "//gameOverContainer")?.run(.sequence([
             .fadeOut(withDuration: 0.15),

--- a/tictactoe Shared/GameScene.swift
+++ b/tictactoe Shared/GameScene.swift
@@ -26,15 +26,15 @@ class GameScene: SKScene {
 
     // MARK: - Properties
 
-    private(set) var boardNode: SKNode!
-    private(set) var cellNodes: [[SKSpriteNode?]] = []
-    private(set) var winningLineNode: SKShapeNode?
+    private var boardNode: SKNode!
+    private var cellNodes: [[SKSpriteNode?]] = []
+    private var winningLineNode: SKShapeNode?
 
     private let boardSize: Int
-    private(set) var gameLogic: GameLogic
+    private var gameLogic: GameLogic
 
-    private(set) var cellSize: CGFloat = 0
-    private(set) var boardOriginOffset: CGPoint = .zero
+    private var cellSize: CGFloat = 0
+    private var boardOriginOffset: CGPoint = .zero
 
     private var isGameOver: Bool { gameLogic.gameState != .ongoing }
 
@@ -47,6 +47,9 @@ class GameScene: SKScene {
     // HUD nodes
     private var turnIndicatorLabel: SKLabelNode?
     private var scoreLabel: SKLabelNode?
+    private var menuButtonNode: SKNode?
+    private var undoButtonNode: SKNode?
+    private var undoButtonLabel: SKLabelNode?
 
     private static let log = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.cascadiacollections.tictactoe",
@@ -55,7 +58,7 @@ class GameScene: SKScene {
 
     // MARK: - Initialization
 
-    init?(boardSize: Int = 3, size: CGSize) {
+    init?(size: CGSize, boardSize: Int = 3) {
         guard let logic = GameLogic(boardSize: boardSize) else {
             Self.log.error("Failed to init GameLogic for boardSize=\(boardSize)")
             return nil
@@ -63,9 +66,23 @@ class GameScene: SKScene {
         self.boardSize = boardSize
         self.gameLogic = logic
         super.init(size: size)
-        anchorPoint = CGPoint(x: 0.5, y: 0.5)
-        scaleMode = .aspectFill
-        backgroundColor = .clear
+        applySceneDefaults()
+    }
+
+    /// Creates a scene that restores a previously persisted in-progress game,
+    /// including its session scores.
+    init?(size: CGSize, restoring persisted: PersistedGame) {
+        guard let logic = GameLogic.restored(from: persisted.snapshot) else {
+            Self.log.error("Failed to restore GameLogic from snapshot")
+            return nil
+        }
+        self.boardSize = logic.boardSize
+        self.gameLogic = logic
+        super.init(size: size)
+        self.xWins = persisted.xWins
+        self.oWins = persisted.oWins
+        self.draws = persisted.draws
+        applySceneDefaults()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -76,6 +93,12 @@ class GameScene: SKScene {
         boardSize = logic.boardSize
         gameLogic = logic
         super.init(coder: aDecoder)
+    }
+
+    private func applySceneDefaults() {
+        anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        scaleMode = .aspectFill
+        backgroundColor = .clear
     }
 
     // MARK: - Scene Lifecycle
@@ -93,9 +116,13 @@ class GameScene: SKScene {
     // MARK: - Board Setup
 
     private func setupBoard() {
-        children.forEach { $0.removeFromParent() }
+        removeAllActions()
+        children.forEach { $0.removeAllActions(); $0.removeFromParent() }
         turnIndicatorLabel = nil
         scoreLabel = nil
+        menuButtonNode = nil
+        undoButtonNode = nil
+        undoButtonLabel = nil
 
         boardNode = SKNode()
         boardNode.alpha = 0
@@ -104,9 +131,22 @@ class GameScene: SKScene {
         calculateBoardLayout()
         cellNodes = Array(repeating: Array(repeating: nil, count: boardSize), count: boardSize)
         drawBoardGrid()
+        renderExistingMoves()
         setupHUD()
 
         boardNode.run(.fadeIn(withDuration: 0.3))
+    }
+
+    /// Renders any pieces already placed in the underlying `gameLogic`.
+    /// Used when the scene is restored from a persisted snapshot.
+    private func renderExistingMoves() {
+        for row in 0..<boardSize {
+            for col in 0..<boardSize {
+                if let player = gameLogic.getPlayerAt(row: row, col: col) {
+                    updateTile(row: row, col: col, player: player, animated: false)
+                }
+            }
+        }
     }
 
     private func calculateBoardLayout() {
@@ -122,6 +162,8 @@ class GameScene: SKScene {
                 let cell = SKSpriteNode(color: .clear, size: CGSize(width: cellSize, height: cellSize))
                 cell.position = position(forRow: row, col: col)
                 cell.name = "cell_\(row)_\(col)"
+                cell.isAccessibilityElement = true
+                cell.accessibilityLabel = "Row \(row + 1), column \(col + 1), empty"
                 cell.addChild(makeCellBorderNode())
                 boardNode.addChild(cell)
                 cellNodes[row][col] = cell
@@ -157,7 +199,87 @@ class GameScene: SKScene {
         addChild(score)
         scoreLabel = score
 
+        setupMenuButton(boardDim: boardDim)
+        setupUndoButton(boardDim: boardDim)
+
         updateHUD()
+    }
+
+    private func setupMenuButton(boardDim: CGFloat) {
+        let buttonWidth = cellSize * 1.35
+        let buttonHeight = cellSize * 0.48
+
+        let (container, _) = makePillButton(
+            title: "≡ Menu",
+            name: "menuButton",
+            size: CGSize(width: buttonWidth, height: buttonHeight)
+        )
+        container.position = CGPoint(
+            x: -boardDim / 2 + buttonWidth / 2,
+            y: boardDim / 2 + cellSize * 0.42
+        )
+        addChild(container)
+        menuButtonNode = container
+    }
+
+    private func setupUndoButton(boardDim: CGFloat) {
+        let buttonWidth = cellSize * 1.35
+        let buttonHeight = cellSize * 0.48
+
+        let (container, label) = makePillButton(
+            title: "↶ Undo",
+            name: "undoButton",
+            size: CGSize(width: buttonWidth, height: buttonHeight)
+        )
+        container.position = CGPoint(
+            x: boardDim / 2 - buttonWidth / 2,
+            y: boardDim / 2 + cellSize * 0.42
+        )
+        addChild(container)
+        undoButtonNode = container
+        undoButtonLabel = label
+    }
+
+    /// Returns `true` when `location` (in scene coordinates) falls inside
+    /// the fixed-size rect of a pill button built by `makePillButton`.
+    private func pillButtonContains(_ button: SKNode, point location: CGPoint) -> Bool {
+        guard let data = button.userData,
+              let w = data["hitW"] as? CGFloat,
+              let h = data["hitH"] as? CGFloat else {
+            return button.calculateAccumulatedFrame().contains(location)
+        }
+        let origin = CGPoint(x: button.position.x - w / 2, y: button.position.y - h / 2)
+        return CGRect(origin: origin, size: CGSize(width: w, height: h)).contains(location)
+    }
+
+    /// Factory for rounded HUD buttons. Returns the container and its label so
+    /// callers can restyle the text (e.g. to show a disabled state).
+    private func makePillButton(title: String, name: String, size: CGSize) -> (SKNode, SKLabelNode) {
+        let container = SKNode()
+        container.name = name
+        container.zPosition = 6
+        container.userData = ["hitW": size.width, "hitH": size.height]
+        container.isAccessibilityElement = true
+        container.accessibilityLabel = title
+
+        let bg = SKShapeNode(
+            rect: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height),
+            cornerRadius: size.height * 0.3
+        )
+        bg.fillColor = GameColor.systemGray6
+        bg.strokeColor = GameColor.systemGray3
+        bg.lineWidth = 1.5
+        container.addChild(bg)
+
+        let label = SKLabelNode(text: title)
+        label.fontName = "HelveticaNeue-Medium"
+        label.fontSize = size.height * 0.45
+        label.fontColor = GameColor.label
+        label.verticalAlignmentMode = .center
+        label.horizontalAlignmentMode = .center
+        container.addChild(label)
+
+        return (container, label)
     }
 
     private func updateHUD() {
@@ -171,7 +293,11 @@ class GameScene: SKScene {
         case .won, .draw:
             turnIndicatorLabel?.isHidden = true
         }
-        scoreLabel?.text = "X: \(xWins)   ·   Draw: \(draws)   ·   O: \(oWins)"
+        scoreLabel?.text = "X: \(xWins)   ·   Draws: \(draws)   ·   O: \(oWins)"
+
+        // Dim the Undo button when there's nothing to undo.
+        undoButtonNode?.alpha = gameLogic.canUndo ? 1.0 : 0.35
+        undoButtonLabel?.fontColor = gameLogic.canUndo ? GameColor.label : GameColor.secondaryLabel
     }
 
     // MARK: - Coordinate Helpers
@@ -207,6 +333,17 @@ class GameScene: SKScene {
 
     private func handleInteraction(at location: CGPoint) {
         guard !isResetting else { return }
+
+        // HUD buttons take precedence over any board interaction.
+        if let menu = menuButtonNode, pillButtonContains(menu, point: location) {
+            returnToMainMenu()
+            return
+        }
+        if let undo = undoButtonNode, pillButtonContains(undo, point: location) {
+            performUndo()
+            return
+        }
+
         if isGameOver { resetGame(); return }
         guard let (row, col) = cellCoordinates(from: location) else { return }
         let mover = gameLogic.currentPlayer
@@ -215,44 +352,126 @@ class GameScene: SKScene {
             Self.log.info("Move \(mover.symbol) at (\(row), \(col))")
             updateTile(row: row, col: col, player: mover)
             checkGameState()
-        case .failure_positionTaken:
+            persistCurrentState()
+        case .failurePositionTaken:
             Self.log.debug("Cell (\(row), \(col)) already taken")
             animateCellShake(row: row, col: col)
-        case .failure_invalidCoordinates:
+        case .failureInvalidCoordinates:
             Self.log.error("Invalid coords (\(row), \(col)) reached handleInteraction")
-        case .failure_gameAlreadyOver:
+        case .failureGameAlreadyOver:
             Self.log.debug("Move attempted after game ended")
         }
     }
 
+    // MARK: - Undo
+
+    private func performUndo() {
+        guard !isResetting, gameLogic.canUndo else { return }
+
+        // Capture the terminal state *before* the undo clears it, so we know
+        // whether to roll back a win or a draw from the session scores.
+        let priorState = gameLogic.gameState
+        guard let reverted = gameLogic.undo() else { return }
+        Self.log.info("Undid \(reverted.player.symbol) at (\(reverted.row), \(reverted.col))")
+
+        switch priorState {
+        case .won(let winner):
+            dismissGameOverUI()
+            if winner == .x { xWins = max(0, xWins - 1) } else { oWins = max(0, oWins - 1) }
+        case .draw:
+            dismissGameOverUI()
+            draws = max(0, draws - 1)
+        case .ongoing:
+            break
+        }
+
+        removeTile(row: reverted.row, col: reverted.col)
+        StatsStore.rollBack(priorState)
+        updateHUD()
+        persistCurrentState()
+    }
+
+    private func dismissGameOverUI() {
+        childNode(withName: "//gameOverContainer")?.removeFromParent()
+        winningLineNode?.removeFromParent()
+        winningLineNode = nil
+    }
+
+    private func removeTile(row: Int, col: Int) {
+        guard let cellOpt = cellNodes[safe: row]?[safe: col], let cell = cellOpt else { return }
+        cell.accessibilityLabel = "Row \(row + 1), column \(col + 1), empty"
+        for child in cell.children where child is SKLabelNode {
+            child.run(.sequence([
+                .scale(to: 0, duration: 0.08),
+                .removeFromParent()
+            ]))
+        }
+    }
+
+    // MARK: - Persistence
+
+    /// Saves the current logical state when a game is in progress; clears the
+    /// persisted slot once the game has ended so the next launch returns to
+    /// the main menu.
+    private func persistCurrentState() {
+        guard gameLogic.gameState == .ongoing else {
+            GamePersistence.clear()
+            return
+        }
+        let persisted = PersistedGame(
+            snapshot: gameLogic.snapshot(),
+            xWins: xWins,
+            oWins: oWins,
+            draws: draws
+        )
+        GamePersistence.save(persisted)
+    }
+
+    // MARK: - Navigation
+
+    private func returnToMainMenu() {
+        Self.log.info("Returning to main menu")
+        GamePersistence.clear()
+        guard let view else { return }
+        let menu = MainMenuScene(size: view.bounds.size)
+        menu.scaleMode = .aspectFill
+        view.presentScene(menu, transition: .fade(withDuration: 0.25))
+    }
+
     // MARK: - Rendering
 
-    private func updateTile(row: Int, col: Int, player: Player) {
+    private func updateTile(row: Int, col: Int, player: Player, animated: Bool = true) {
         guard let cellOpt = cellNodes[safe: row]?[safe: col],
               let cell = cellOpt else { return }
-        let label = SKLabelNode(text: player == .x ? "X" : "O")
+        let letter = player == .x ? "X" : "O"
+        let label = SKLabelNode(text: letter)
         label.fontSize = cellSize * 0.55
         label.fontColor = player == .x ? GameColor.systemRed : GameColor.systemBlue
         label.fontName = "HelveticaNeue-Bold"
         label.verticalAlignmentMode = .center
         label.horizontalAlignmentMode = .center
-        label.setScale(0)
+        label.setScale(animated ? 0 : 1)
         cell.addChild(label)
-        label.run(.sequence([
-            .scale(to: 1.2, duration: 0.10),
-            .scale(to: 1.0, duration: 0.08)
-        ]))
+        cell.accessibilityLabel = "Row \(row + 1), column \(col + 1), \(letter)"
+        if animated {
+            label.run(.sequence([
+                .scale(to: 1.2, duration: 0.10),
+                .scale(to: 1.0, duration: 0.08)
+            ]))
+        }
     }
 
     private func checkGameState() {
         switch gameLogic.gameState {
         case .won(let winner):
             if winner == .x { xWins += 1 } else { oWins += 1 }
+            StatsStore.recordWin(for: winner)
             displayWinningLine(for: winner)
             displayGameOverMessage("\(winner == .x ? "X" : "O") Wins! 🎉", winner: winner)
             updateHUD()
         case .draw:
             draws += 1
+            StatsStore.recordDraw()
             displayGameOverMessage("It's a Draw! 🤝")
             updateHUD()
         case .ongoing:
@@ -348,16 +567,20 @@ class GameScene: SKScene {
         isResetting = true
 
         gameLogic.reset()
+        // Starting a fresh round — nothing to restore until the next move.
+        GamePersistence.clear()
 
         childNode(withName: "//gameOverContainer")?.run(.sequence([
             .fadeOut(withDuration: 0.15),
             .removeFromParent()
         ]))
-        winningLineNode?.run(.sequence([
-            .fadeOut(withDuration: 0.15),
-            .removeFromParent()
-        ]))
-        winningLineNode = nil
+        if let line = winningLineNode {
+            winningLineNode = nil
+            line.run(.sequence([
+                .fadeOut(withDuration: 0.15),
+                .removeFromParent()
+            ]))
+        }
 
         for row in 0..<boardSize {
             for col in 0..<boardSize {

--- a/tictactoe Shared/MainMenuScene.swift
+++ b/tictactoe Shared/MainMenuScene.swift
@@ -1,0 +1,248 @@
+import SpriteKit
+import os
+
+// MARK: - MainMenuScene
+
+/// The app's landing scene. Presents a title, lifetime stats, and a list of
+/// board-size options; selecting one transitions to a fresh `GameScene` for
+/// the chosen size.
+///
+/// This scene is bypassed when `GamePersistence.load()` returns an
+/// in-progress game — see `GameViewController`.
+@MainActor
+final class MainMenuScene: SKScene {
+
+    // MARK: - Configuration
+
+    /// Board sizes offered on the menu.
+    private static let offeredBoardSizes: [Int] = [3, 4, 5]
+
+    // MARK: - State
+
+    private var boardSizeButtons: [(node: SKNode, boardSize: Int)] = []
+    private var statsLabel: SKLabelNode?
+    private var resetStatsButton: SKNode?
+
+    private static let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.cascadiacollections.tictactoe",
+        category: "MainMenuScene"
+    )
+
+    // MARK: - Initialization
+
+    override init(size: CGSize) {
+        super.init(size: size)
+        anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        scaleMode = .aspectFill
+        backgroundColor = .clear
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    // MARK: - Scene Lifecycle
+
+    override func didMove(to view: SKView) {
+        Self.log.debug("didMove size=\(self.size.width)x\(self.size.height)")
+        buildMenu()
+    }
+
+    override func didChangeSize(_ oldSize: CGSize) {
+        guard oldSize != size, !children.isEmpty else { return }
+        buildMenu()
+    }
+
+    // MARK: - Layout
+
+    private func buildMenu() {
+        removeAllChildren()
+        boardSizeButtons.removeAll()
+        statsLabel = nil
+        resetStatsButton = nil
+
+        let unit = min(size.width, size.height) / 10.0
+
+        let title = SKLabelNode(text: "Tic Tac Toe")
+        title.fontName = "HelveticaNeue-Bold"
+        title.fontSize = unit * 1.25
+        title.fontColor = GameColor.label
+        title.verticalAlignmentMode = .center
+        title.horizontalAlignmentMode = .center
+        title.position = CGPoint(x: 0, y: unit * 3.5)
+        title.zPosition = 5
+        addChild(title)
+
+        let subtitle = SKLabelNode(text: "Choose a board size")
+        subtitle.fontName = "HelveticaNeue"
+        subtitle.fontSize = unit * 0.55
+        subtitle.fontColor = GameColor.secondaryLabel
+        subtitle.verticalAlignmentMode = .center
+        subtitle.horizontalAlignmentMode = .center
+        subtitle.position = CGPoint(x: 0, y: unit * 2.55)
+        subtitle.zPosition = 5
+        addChild(subtitle)
+
+        layoutBoardSizeButtons(unit: unit)
+        layoutStatsFooter(unit: unit)
+    }
+
+    private func layoutBoardSizeButtons(unit: CGFloat) {
+        let buttonWidth = unit * 5.2
+        let buttonHeight = unit * 1.3
+        let spacing = unit * 0.35
+
+        let sizes = Self.offeredBoardSizes
+        let totalHeight = CGFloat(sizes.count) * buttonHeight + CGFloat(sizes.count - 1) * spacing
+        var y = totalHeight / 2 - buttonHeight / 2
+
+        for boardSize in sizes {
+            let button = makeButton(
+                title: "\(boardSize) × \(boardSize)",
+                size: CGSize(width: buttonWidth, height: buttonHeight),
+                fontSize: unit * 0.7
+            )
+            button.position = CGPoint(x: 0, y: y - unit * 0.4)
+            addChild(button)
+            boardSizeButtons.append((button, boardSize))
+            y -= buttonHeight + spacing
+        }
+    }
+
+    private func layoutStatsFooter(unit: CGFloat) {
+        let stats = StatsStore.load()
+
+        let label = SKLabelNode(text: statsText(from: stats))
+        label.fontName = "HelveticaNeue"
+        label.fontSize = unit * 0.42
+        label.fontColor = GameColor.secondaryLabel
+        label.verticalAlignmentMode = .center
+        label.horizontalAlignmentMode = .center
+        label.numberOfLines = 2
+        label.preferredMaxLayoutWidth = unit * 8
+        label.position = CGPoint(x: 0, y: -unit * 3.35)
+        label.zPosition = 5
+        addChild(label)
+        statsLabel = label
+
+        // Only show a reset control once there's actually something to clear.
+        guard stats.totalGames > 0 else { return }
+
+        let buttonSize = CGSize(width: unit * 2.8, height: unit * 0.7)
+        let reset = makeButton(
+            title: "Reset Stats",
+            size: buttonSize,
+            fontSize: unit * 0.32
+        )
+        reset.name = "resetStatsButton"
+        reset.position = CGPoint(x: 0, y: -unit * 4.25)
+        addChild(reset)
+        resetStatsButton = reset
+    }
+
+    private func statsText(from stats: LifetimeStats) -> String {
+        guard stats.totalGames > 0 else {
+            return "No games played yet"
+        }
+        return """
+        Lifetime: \(stats.totalGames) game\(stats.totalGames == 1 ? "" : "s")
+        X: \(stats.xWins)   ·   Draws: \(stats.draws)   ·   O: \(stats.oWins)
+        """
+    }
+
+    private func refreshStats() {
+        guard let label = statsLabel else { return }
+        let stats = StatsStore.load()
+        label.text = statsText(from: stats)
+        if stats.totalGames == 0 {
+            resetStatsButton?.removeFromParent()
+            resetStatsButton = nil
+        }
+    }
+
+    private func makeButton(title: String, size: CGSize, fontSize: CGFloat) -> SKNode {
+        let container = SKNode()
+        container.name = "menuButton"
+        container.zPosition = 10
+        container.isAccessibilityElement = true
+        container.accessibilityLabel = title
+
+        let background = SKShapeNode(
+            rect: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height),
+            cornerRadius: size.height * 0.22
+        )
+        background.fillColor = GameColor.systemGray6
+        background.strokeColor = GameColor.systemGray3
+        background.lineWidth = 2
+        background.name = "menuButtonBackground"
+        container.addChild(background)
+
+        let label = SKLabelNode(text: title)
+        label.fontName = "HelveticaNeue-Bold"
+        label.fontSize = fontSize
+        label.fontColor = GameColor.label
+        label.verticalAlignmentMode = .center
+        label.horizontalAlignmentMode = .center
+        label.name = "menuButtonLabel"
+        container.addChild(label)
+
+        return container
+    }
+
+    // MARK: - Input
+
+#if os(iOS)
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        handleSelection(at: touch.location(in: self))
+    }
+#elseif os(macOS)
+    override func mouseDown(with event: NSEvent) {
+        handleSelection(at: event.location(in: self))
+    }
+#endif
+
+    private func handleSelection(at location: CGPoint) {
+        if let reset = resetStatsButton, reset.calculateAccumulatedFrame().contains(location) {
+            animateButton(reset) { [weak self] in
+                self?.resetStats()
+            }
+            return
+        }
+        guard let hit = boardSizeButtons.first(where: {
+            $0.node.calculateAccumulatedFrame().contains(location)
+        }) else {
+            return
+        }
+        Self.log.info("Menu selection: \(hit.boardSize)x\(hit.boardSize)")
+        animateButton(hit.node) { [weak self] in
+            self?.startGame(boardSize: hit.boardSize)
+        }
+    }
+
+    private func animateButton(_ node: SKNode, completion: @escaping () -> Void) {
+        let press = SKAction.scale(to: 0.94, duration: 0.06)
+        let release = SKAction.scale(to: 1.0, duration: 0.08)
+        node.run(.sequence([press, release]), completion: completion)
+    }
+
+    // MARK: - Actions
+
+    private func resetStats() {
+        Self.log.info("Lifetime stats reset")
+        StatsStore.reset()
+        refreshStats()
+    }
+
+    private func startGame(boardSize: Int) {
+        guard let view else { return }
+        // Starting a brand-new game — ensure no stale persisted state survives.
+        GamePersistence.clear()
+        guard let scene = GameScene(size: view.bounds.size, boardSize: boardSize) else {
+            Self.log.error("Failed to create GameScene for boardSize=\(boardSize)")
+            return
+        }
+        scene.scaleMode = .aspectFill
+        view.presentScene(scene, transition: .fade(withDuration: 0.25))
+    }
+}

--- a/tictactoe Shared/MainMenuScene.swift
+++ b/tictactoe Shared/MainMenuScene.swift
@@ -1,0 +1,175 @@
+import SpriteKit
+import os
+
+// MARK: - MainMenuScene
+
+/// The app's landing scene. Presents a title and a list of board-size options;
+/// selecting one transitions to a fresh `GameScene` for the chosen size.
+///
+/// This scene is bypassed when `GamePersistence.load()` returns an
+/// in-progress game — see `GameViewController`.
+@MainActor
+final class MainMenuScene: SKScene {
+
+    // MARK: - Configuration
+
+    /// Board sizes offered on the menu.
+    private static let offeredBoardSizes: [Int] = [3, 4, 5]
+
+    // MARK: - State
+
+    private var buttons: [(node: SKNode, boardSize: Int)] = []
+    private var titleLabel: SKLabelNode?
+    private var subtitleLabel: SKLabelNode?
+
+    private static let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.cascadiacollections.tictactoe",
+        category: "MainMenuScene"
+    )
+
+    // MARK: - Initialization
+
+    override init(size: CGSize) {
+        super.init(size: size)
+        anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        scaleMode = .aspectFill
+        backgroundColor = .clear
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    // MARK: - Scene Lifecycle
+
+    override func didMove(to view: SKView) {
+        Self.log.debug("didMove size=\(self.size.width)x\(self.size.height)")
+        buildMenu()
+    }
+
+    override func didChangeSize(_ oldSize: CGSize) {
+        guard oldSize != size, !children.isEmpty else { return }
+        buildMenu()
+    }
+
+    // MARK: - Layout
+
+    private func buildMenu() {
+        removeAllChildren()
+        buttons.removeAll()
+        titleLabel = nil
+        subtitleLabel = nil
+
+        let unit = min(size.width, size.height) / 10.0
+
+        let title = SKLabelNode(text: "Tic Tac Toe")
+        title.fontName = "HelveticaNeue-Bold"
+        title.fontSize = unit * 1.25
+        title.fontColor = GameColor.label
+        title.verticalAlignmentMode = .center
+        title.horizontalAlignmentMode = .center
+        title.position = CGPoint(x: 0, y: unit * 3.2)
+        title.zPosition = 5
+        addChild(title)
+        titleLabel = title
+
+        let subtitle = SKLabelNode(text: "Choose a board size")
+        subtitle.fontName = "HelveticaNeue"
+        subtitle.fontSize = unit * 0.55
+        subtitle.fontColor = GameColor.secondaryLabel
+        subtitle.verticalAlignmentMode = .center
+        subtitle.horizontalAlignmentMode = .center
+        subtitle.position = CGPoint(x: 0, y: unit * 2.1)
+        subtitle.zPosition = 5
+        addChild(subtitle)
+        subtitleLabel = subtitle
+
+        let buttonWidth = unit * 5.2
+        let buttonHeight = unit * 1.3
+        let spacing = unit * 0.35
+
+        let sizes = Self.offeredBoardSizes
+        let totalHeight = CGFloat(sizes.count) * buttonHeight + CGFloat(sizes.count - 1) * spacing
+        var y = totalHeight / 2 - buttonHeight / 2
+
+        for boardSize in sizes {
+            let button = makeButton(
+                title: "\(boardSize) × \(boardSize)",
+                size: CGSize(width: buttonWidth, height: buttonHeight),
+                fontSize: unit * 0.7
+            )
+            button.position = CGPoint(x: 0, y: y - unit * 0.2)
+            addChild(button)
+            buttons.append((button, boardSize))
+            y -= buttonHeight + spacing
+        }
+    }
+
+    private func makeButton(title: String, size: CGSize, fontSize: CGFloat) -> SKNode {
+        let container = SKNode()
+        container.name = "menuButton"
+        container.zPosition = 10
+
+        let background = SKShapeNode(
+            rect: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height),
+            cornerRadius: size.height * 0.22
+        )
+        background.fillColor = GameColor.systemGray6
+        background.strokeColor = GameColor.systemGray3
+        background.lineWidth = 2
+        background.name = "menuButtonBackground"
+        container.addChild(background)
+
+        let label = SKLabelNode(text: title)
+        label.fontName = "HelveticaNeue-Bold"
+        label.fontSize = fontSize
+        label.fontColor = GameColor.label
+        label.verticalAlignmentMode = .center
+        label.horizontalAlignmentMode = .center
+        label.name = "menuButtonLabel"
+        container.addChild(label)
+
+        return container
+    }
+
+    // MARK: - Input
+
+#if os(iOS)
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        handleSelection(at: touch.location(in: self))
+    }
+#elseif os(macOS)
+    override func mouseDown(with event: NSEvent) {
+        handleSelection(at: event.location(in: self))
+    }
+#endif
+
+    private func handleSelection(at location: CGPoint) {
+        guard let hit = buttons.first(where: { $0.node.calculateAccumulatedFrame().contains(location) }) else {
+            return
+        }
+        Self.log.info("Menu selection: \(hit.boardSize)x\(hit.boardSize)")
+        animateButton(hit.node) { [weak self] in
+            self?.startGame(boardSize: hit.boardSize)
+        }
+    }
+
+    private func animateButton(_ node: SKNode, completion: @escaping () -> Void) {
+        let press = SKAction.scale(to: 0.94, duration: 0.06)
+        let release = SKAction.scale(to: 1.0, duration: 0.08)
+        node.run(.sequence([press, release]), completion: completion)
+    }
+
+    private func startGame(boardSize: Int) {
+        guard let view else { return }
+        // Starting a brand-new game — ensure no stale persisted state survives.
+        GamePersistence.clear()
+        guard let scene = GameScene(size: view.bounds.size, boardSize: boardSize) else {
+            Self.log.error("Failed to create GameScene for boardSize=\(boardSize)")
+            return
+        }
+        scene.scaleMode = .aspectFill
+        view.presentScene(scene, transition: .fade(withDuration: 0.25))
+    }
+}

--- a/tictactoe iOS/AppDelegate.swift
+++ b/tictactoe iOS/AppDelegate.swift
@@ -9,13 +9,11 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
-
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        return true
+        true
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
@@ -39,7 +37,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-
 }
-

--- a/tictactoe iOS/GameViewController.swift
+++ b/tictactoe iOS/GameViewController.swift
@@ -21,12 +21,14 @@ class GameViewController: UIViewController {
         let viewSize = skView.bounds.size
         Self.log.debug("SKView bounds size: \(viewSize.width)x\(viewSize.height)")
 
-        guard let scene = GameScene(size: viewSize) else {
-            Self.log.error("Could not initialize GameScene")
-            let alert = UIAlertController(title: "Error", message: "Could not start the game.", preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
-            return
+        let scene: SKScene
+        if let persisted = GamePersistence.load(),
+           let restored = GameScene(size: viewSize, restoring: persisted) {
+            // Skip the main menu and drop the player straight back into their game.
+            Self.log.info("Restoring in-progress game — bypassing main menu")
+            scene = restored
+        } else {
+            scene = MainMenuScene(size: viewSize)
         }
 
         scene.scaleMode = .aspectFill

--- a/tictactoe iOS/GameViewController.swift
+++ b/tictactoe iOS/GameViewController.swift
@@ -1,10 +1,16 @@
-import UIKit
+//
+//  GameViewController.swift
+//  tictactoe iOS
+//
+//  Created by Kevin T. Coughlin on 6/10/24.
+//
+
 import SpriteKit
+import UIKit
 import os
 
 @MainActor
 class GameViewController: UIViewController {
-
     private static let log = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.cascadiacollections.tictactoe",
         category: "GameViewController"
@@ -47,4 +53,3 @@ class GameViewController: UIViewController {
 
     override var prefersStatusBarHidden: Bool { true }
 }
-

--- a/tictactoe macOS/GameViewController.swift
+++ b/tictactoe macOS/GameViewController.swift
@@ -21,10 +21,16 @@ class GameViewController: NSViewController {
         let viewSize = skView.bounds.size
         Self.log.debug("SKView bounds size: \(viewSize.width)x\(viewSize.height)")
 
-        guard let scene = GameScene(size: viewSize) else {
-            Self.log.error("Could not initialize GameScene")
-            return
+        let scene: SKScene
+        if let persisted = GamePersistence.load(),
+           let restored = GameScene(size: viewSize, restoring: persisted) {
+            // Skip the main menu and drop the player straight back into their game.
+            Self.log.info("Restoring in-progress game — bypassing main menu")
+            scene = restored
+        } else {
+            scene = MainMenuScene(size: viewSize)
         }
+
         scene.scaleMode = .aspectFill
         skView.presentScene(scene)
         skView.ignoresSiblingOrder = true

--- a/tictactoe macOS/GameViewController.swift
+++ b/tictactoe macOS/GameViewController.swift
@@ -1,10 +1,16 @@
+//
+//  GameViewController.swift
+//  tictactoe macOS
+//
+//  Created by Kevin T. Coughlin on 6/10/24.
+//
+
 import Cocoa
 import SpriteKit
 import os
 
 @MainActor
 class GameViewController: NSViewController {
-
     private static let log = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.cascadiacollections.tictactoe",
         category: "GameViewController"
@@ -41,4 +47,3 @@ class GameViewController: NSViewController {
         #endif
     }
 }
-

--- a/tictactoe.xcodeproj/project.pbxproj
+++ b/tictactoe.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		0BD7A1FF2C17A6B600378A1D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0BD7A1C42C17A6B600378A1D /* Assets.xcassets */; };
 		0BEDDA602CD1F9D700DC5330 /* GameLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEDDA5E2CD1F9D700DC5330 /* GameLogic.swift */; };
 		0BEDDA612CD1F9D700DC5330 /* GameLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEDDA5E2CD1F9D700DC5330 /* GameLogic.swift */; };
+		0BEDDB012DF0010000DC5330 /* MainMenuScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEDDB002DF0010000DC5330 /* MainMenuScene.swift */; };
+		0BEDDB022DF0010000DC5330 /* MainMenuScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEDDB002DF0010000DC5330 /* MainMenuScene.swift */; };
+		0BEDDB042DF0010000DC5330 /* GamePersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEDDB032DF0010000DC5330 /* GamePersistence.swift */; };
+		0BEDDB052DF0010000DC5330 /* GamePersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEDDB032DF0010000DC5330 /* GamePersistence.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +57,8 @@
 		0BD7A2112C17E5A300378A1D /* libswiftUIKit.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libswiftUIKit.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/usr/lib/swift/libswiftUIKit.tbd; sourceTree = DEVELOPER_DIR; };
 		0BD7A2122C18021E00378A1D /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		0BEDDA5E2CD1F9D700DC5330 /* GameLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameLogic.swift; sourceTree = "<group>"; };
+		0BEDDB002DF0010000DC5330 /* MainMenuScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuScene.swift; sourceTree = "<group>"; };
+		0BEDDB032DF0010000DC5330 /* GamePersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamePersistence.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +114,8 @@
 				0BD7A1C32C17A6B400378A1D /* GameScene.swift */,
 				0BD7A1C42C17A6B600378A1D /* Assets.xcassets */,
 				0BEDDA5E2CD1F9D700DC5330 /* GameLogic.swift */,
+				0BEDDB002DF0010000DC5330 /* MainMenuScene.swift */,
+				0BEDDB032DF0010000DC5330 /* GamePersistence.swift */,
 			);
 			path = "tictactoe Shared";
 			sourceTree = "<group>";
@@ -295,6 +303,8 @@
 				0BD7A1FA2C17A6B600378A1D /* GameScene.swift in Sources */,
 				0BD7A1CF2C17A6B600378A1D /* GameViewController.swift in Sources */,
 				0BEDDA612CD1F9D700DC5330 /* GameLogic.swift in Sources */,
+				0BEDDB012DF0010000DC5330 /* MainMenuScene.swift in Sources */,
+				0BEDDB042DF0010000DC5330 /* GamePersistence.swift in Sources */,
 				0BD7A1CD2C17A6B600378A1D /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -306,6 +316,8 @@
 				0BD7A1FC2C17A6B600378A1D /* GameScene.swift in Sources */,
 				0BD7A1EF2C17A6B600378A1D /* GameViewController.swift in Sources */,
 				0BEDDA602CD1F9D700DC5330 /* GameLogic.swift in Sources */,
+				0BEDDB022DF0010000DC5330 /* MainMenuScene.swift in Sources */,
+				0BEDDB052DF0010000DC5330 /* GamePersistence.swift in Sources */,
 				0BD7A1ED2C17A6B600378A1D /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Add a MainMenuScene that lets players pick a board size (3×3, 4×4, 5×5)
and transition into a fresh GameScene. On launch, the view controllers
check GamePersistence for an in-progress game and, when found, bypass
the menu and restore the player straight into their saved game —
including session scores.

Persistence is backed by UserDefaults. The GameScene saves after every
successful move and clears the slot on game over, reset, or when the
user taps the new in-game Menu button. GameLogic gains a GameSnapshot
value type plus snapshot()/init(snapshot:) round-trip support, with
Codable added to Player and GameState.